### PR TITLE
RFC: A parallel implementation of summator_incompr

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -31,7 +31,10 @@ jobs:
       - uses: actions-rs/cargo@v1
         with:
           command: clippy
-          args: -- --deny warnings
+          args: --all-targets -- --deny warnings
+      - uses: actions-rs/cargo@v1
+        with:
+          command: test
 
   build_for_linux:
     name: Build for Linux

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,8 +13,15 @@ license = "LGPL-3.0-or-later"
 name = "gstools_core"
 crate-type = ["cdylib", "rlib"]
 
+[profile.release]
+panic = "abort"
+lto = true
+codegen-units = 1
+
 [profile.bench]
 debug = true
+lto = true
+codegen-units = 1
 
 [dependencies]
 numpy = "0.14.1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,11 +22,14 @@ rayon = "1.5.1"
 
 [dependencies.ndarray]
 version = "0.15.3"
-features = ["rayon"]
+features = ["rayon", "approx"]
 
 [dependencies.pyo3]
 version = "0.14.3"
 features = ["extension-module"]
+
+[dev-dependencies]
+approx = "0.4"
 
 [dev-dependencies.criterion]
 version = "0.3.5"

--- a/src/field.rs
+++ b/src/field.rs
@@ -62,12 +62,13 @@ pub fn summator_incompr(
                         let k_2 = cov_samples.dot(&cov_samples);
                         let phase = cov_samples.dot(&pos);
 
-                        Zip::from(&mut sum).and(&e1).and(cov_samples).par_for_each(
-                            |sum, e1, cs| {
+                        Zip::from(&mut sum)
+                            .and(&e1)
+                            .and(cov_samples)
+                            .for_each(|sum, e1, cs| {
                                 let proj = *e1 - cs * cov_samples[0] / k_2;
                                 *sum += proj * (z1 * phase.cos() + z2 * phase.sin());
-                            },
-                        );
+                            });
 
                         sum
                     },

--- a/src/field.rs
+++ b/src/field.rs
@@ -89,6 +89,8 @@ pub fn summator_incompr(
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    use approx::assert_ulps_eq;
     use ndarray::{arr1, arr2};
 
     struct Setup {
@@ -155,7 +157,7 @@ mod tests {
     fn test_summate_incompr_3d() {
         let setup = Setup::new();
 
-        assert_eq!(
+        assert_ulps_eq!(
             summator_incompr(
                 setup.cov_samples.view(),
                 setup.z_1.view(),
@@ -193,7 +195,8 @@ mod tests {
                     -0.0656185245433833,
                     1.6593799470196355
                 ]
-            ])
+            ]),
+            max_ulps = 6
         );
     }
 }


### PR DESCRIPTION
I was not able to write this without downgrading the `ndarray::Zip` into a parallel iterator and it needs to store the sums into temporary arrays which implies additional allocations so I am not sure if this is a win at all. (And I could not benchmark it as I do not have the `gstools` Python package installed yet.)

What is quite interesting is that the test started to fail due to associativity artefacts introduced by parallelization which groups the summands differently than the serial version. I worked around this by using the `approx` crate to relax the comparison to 6 ULPS. (An alternative would have been to always run the tests using `RAYON_NUM_THREADS=1` but not making bit-for-bit comparisons of floating-point numbers seems generally advisable.)