### PR TITLE
Two miscellaneous nits

### DIFF
--- a/benches/main.rs
+++ b/benches/main.rs
@@ -20,21 +20,21 @@ fn read_2d_from_file(file_path: &Path) -> Array2<f64> {
     let file = File::open(file_path).expect("File wasn't found");
     let reader = BufReader::new(file);
 
-    let vec: Vec<Array1<f64>> = reader
-        .lines()
-        .map(|l| {
-            l.unwrap()
-                .split(char::is_whitespace)
-                .map(|number| number.parse::<f64>().unwrap())
-                .collect()
-        })
-        .collect();
+    let mut vec = Vec::new();
+    let mut lines = 0;
 
-    let shape = (vec.len(), vec[0].dim());
+    for line in reader.lines() {
+        vec.extend(
+            line.unwrap()
+                .split_whitespace()
+                .map(|number| number.parse::<f64>().unwrap()),
+        );
+        lines += 1;
+    }
 
-    let flat_vec: Vec<f64> = vec.iter().flatten().cloned().collect();
+    let shape = (lines, vec.len() / lines);
 
-    Array2::from_shape_vec(shape, flat_vec).unwrap()
+    Array2::from_shape_vec(shape, vec).unwrap()
 }
 
 pub fn field_benchmark(c: &mut Criterion) {

--- a/src/field.rs
+++ b/src/field.rs
@@ -1,5 +1,4 @@
 use ndarray::{Array1, Array2, ArrayView1, ArrayView2, Zip};
-
 use rayon::prelude::*;
 
 pub fn summator(
@@ -21,13 +20,12 @@ pub fn summator(
                 .and(z1)
                 .and(z2)
                 .for_each(|sample, &z1, &z2| {
-                    let mut phase = 0.0;
-                    Zip::from(sample).and(pos).for_each(|&s, &p| {
-                        phase += s * p;
-                    });
+                    let phase = sample.dot(&pos);
+
                     *sum += z1 * phase.cos() + z2 * phase.sin();
                 })
         });
+
     summed_modes
 }
 

--- a/src/krige.rs
+++ b/src/krige.rs
@@ -20,12 +20,9 @@ pub fn calculator_field_krige_and_variance(
                 .and(v_col)
                 .and(krig_mat.columns())
                 .for_each(|c, v, m_row| {
-                    let mut krig_fac = 0.0;
-                    Zip::from(m_row).and(v_col).for_each(|m, v| {
-                        krig_fac += m * v;
-                    });
-                    *e += v * krig_fac;
+                    let krig_fac = m_row.dot(&v_col);
                     *f += c * krig_fac;
+                    *e += v * krig_fac;
                 });
         });
 
@@ -49,10 +46,7 @@ pub fn calculator_field_krige(
             Zip::from(cond)
                 .and(krig_mat.columns())
                 .for_each(|c, m_row| {
-                    let mut krig_fac = 0.0;
-                    Zip::from(m_row).and(v_col).for_each(|m, v| {
-                        krig_fac += m * v;
-                    });
+                    let krig_fac = m_row.dot(&v_col);
                     *f += c * krig_fac;
                 });
         });
@@ -63,6 +57,7 @@ pub fn calculator_field_krige(
 #[cfg(test)]
 mod tests {
     use super::*;
+
     use approx::assert_ulps_eq;
     use ndarray::{arr1, arr2, Array2};
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -12,7 +12,6 @@ pub mod krige;
 pub mod variogram;
 
 #[pymodule]
-#[allow(non_snake_case)]
 fn gstools_core(_py: Python<'_>, m: &PyModule) -> PyResult<()> {
     #[pyfn(m)]
     #[pyo3(name = "summate")]


### PR DESCRIPTION
* Use `dot` instead of manually zipping arrays in `field` and `krige` modules
* In benchmark `main`, do not allocate an array of arrays only to flatten it back again