### PR TITLE
Drop the dimension parameter of variogram_directional and variogram_unstructed

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -48,9 +48,9 @@ dependencies = [
 
 [[package]]
 name = "bumpalo"
-version = "3.7.1"
+version = "3.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d9df67f7bf9ef8498769f994239c45613ef0c5899415fb58e9add412d2c1a538"
+checksum = "8f1e260c3a9040a7c19a12468758f4c16f31a81a1fe087482be9570ec864bb6c"
 
 [[package]]
 name = "cast"
@@ -205,7 +205,7 @@ dependencies = [
 
 [[package]]
 name = "gstools-core"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "approx",
  "criterion",
@@ -218,9 +218,9 @@ dependencies = [
 
 [[package]]
 name = "half"
-version = "1.8.0"
+version = "1.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ac5956d4e63858efaec57e0d6c1c2f6a41e1487f830314a324ccd7e2223a7ca0"
+checksum = "eabb4a44450da02c90444cf74558da904edde8fb4e9035a9a6a4e15445af0bd7"
 
 [[package]]
 name = "hermit-abi"
@@ -256,9 +256,9 @@ dependencies = [
 
 [[package]]
 name = "instant"
-version = "0.1.11"
+version = "0.1.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "716d3d89f35ac6a34fd0eed635395f4c3b76fa889338a4632e5231a8684216bd"
+checksum = "7a5bbe824c507c5da5956355e86a746d82e0e1464f65d862cc5e71da70e94b2c"
 dependencies = [
  "cfg-if 1.0.0",
 ]
@@ -295,9 +295,9 @@ checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
 
 [[package]]
 name = "libc"
-version = "0.2.103"
+version = "0.2.105"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dd8f7255a17a627354f321ef0055d63b898c6fb27eff628af4d1b66b7331edf6"
+checksum = "869d572136620d55835903746bcb5cdc54cb2851fd0aeec53220b4bb65ef3013"
 
 [[package]]
 name = "libm"
@@ -512,9 +512,9 @@ dependencies = [
 
 [[package]]
 name = "ppv-lite86"
-version = "0.2.14"
+version = "0.2.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c3ca011bd0129ff4ae15cd04c4eef202cadf6c51c21e47aba319b4e0501db741"
+checksum = "ed0cfbc8191465bed66e1718596ee0b0b35d5ee1f41c5df2189d0fe8bde535ba"
 
 [[package]]
 name = "proc-macro-hack"
@@ -524,9 +524,9 @@ checksum = "dbf0c48bc1d91375ae5c3cd81e3722dff1abcf81a30960240640d223f59fe0e5"
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.30"
+version = "1.0.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "edc3358ebc67bc8b7fa0c007f945b0b18226f78437d61bec735a9eb96b61ee70"
+checksum = "ba508cc11742c0dc5c1659771673afbab7a0efab23aa17e854cbab0837ed0b43"
 dependencies = [
  "unicode-xid",
 ]
@@ -781,9 +781,9 @@ checksum = "1ecab6c735a6bb4139c0caafd0cc3635748bbb3acf4550e8138122099251f309"
 
 [[package]]
 name = "syn"
-version = "1.0.80"
+version = "1.0.81"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d010a1623fbd906d51d650a9916aaefc05ffa0e4053ff7fe601167f3e715d194"
+checksum = "f2afee18b8beb5a596ecb4a2dce128c719b4ba399d34126b9e4396e3f9860966"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "gstools-core"
-version = "0.1.2"
+version = "0.2.0"
 authors = ["Lennart Schüler <mostem@posteo.de>"]
 edition = "2018"
 description = "The core functions of GSTools"

--- a/benches/main.rs
+++ b/benches/main.rs
@@ -115,7 +115,6 @@ pub fn variogram_benchmark(c: &mut Criterion) {
     c.bench_function("variogram unstructured", |b| {
         b.iter(|| {
             variogram_unstructured(
-                2,
                 black_box(f.view()),
                 black_box(bin_edges.view()),
                 black_box(pos.view()),
@@ -130,7 +129,6 @@ pub fn variogram_benchmark(c: &mut Criterion) {
     c.bench_function("variogram directional", |b| {
         b.iter(|| {
             variogram_directional(
-                2,
                 black_box(f.view()),
                 black_box(bin_edges.view()),
                 black_box(pos.view()),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -108,7 +108,6 @@ fn gstools_core(_py: Python<'_>, m: &PyModule) -> PyResult<()> {
     #[allow(clippy::too_many_arguments)]
     fn variogram_directional_py<'py>(
         py: Python<'py>,
-        dim: usize,
         f: PyReadonlyArray2<f64>,
         bin_edges: PyReadonlyArray1<f64>,
         pos: PyReadonlyArray2<f64>,
@@ -127,7 +126,6 @@ fn gstools_core(_py: Python<'_>, m: &PyModule) -> PyResult<()> {
         let separate_dirs = separate_dirs.unwrap_or(false);
         let estimator_type = estimator_type.unwrap_or('m');
         let (variogram, counts) = variogram_directional(
-            dim,
             f,
             bin_edges,
             pos,
@@ -147,7 +145,6 @@ fn gstools_core(_py: Python<'_>, m: &PyModule) -> PyResult<()> {
     #[pyo3(name = "variogram_unstructured")]
     fn variogram_unstructured_py<'py>(
         py: Python<'py>,
-        dim: usize,
         f: PyReadonlyArray2<f64>,
         bin_edges: PyReadonlyArray1<f64>,
         pos: PyReadonlyArray2<f64>,
@@ -160,7 +157,7 @@ fn gstools_core(_py: Python<'_>, m: &PyModule) -> PyResult<()> {
         let estimator_type = estimator_type.unwrap_or('m');
         let distance_type = distance_type.unwrap_or('e');
         let (variogram, counts) =
-            variogram_unstructured(dim, f, bin_edges, pos, estimator_type, distance_type);
+            variogram_unstructured(f, bin_edges, pos, estimator_type, distance_type);
         let variogram = variogram.into_pyarray(py);
         let counts = counts.into_pyarray(py);
 


### PR DESCRIPTION
This parameter is redundant to the shape of the pos and direction arrays.

Fixes #10 