### PR TITLE
Fix double square root in computation of bandwidth distance.

### DIFF
--- a/src/variogram.rs
+++ b/src/variogram.rs
@@ -216,7 +216,7 @@ fn dir_test(
             })
             .sqrt();
 
-        if b_dist.sqrt() >= bandwidth {
+        if b_dist >= bandwidth {
             return false;
         }
     }


### PR DESCRIPTION
This slipped in when refactoring the variogram code is not detected by the current unit tests and I admittedly do not feel confident to write a regression test fixing it.

(As a performance aside, all these distances in the variogram module are used in comparisons. Hence, some of the square roots should be avoidable by squaring the other sides of these inequalities like bandwidth or lower_bin_edge. That squaring could also be done outside of the inner loops to further reduce costs.) 