### PR TITLE
Add Python __version__ to PyModule

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -14,6 +14,8 @@ pub mod variogram;
 
 #[pymodule]
 fn gstools_core(_py: Python<'_>, m: &PyModule) -> PyResult<()> {
+    m.add("__version__", env!("CARGO_PKG_VERSION"))?;
+
     #[pyfn(m)]
     #[pyo3(name = "summate")]
     fn summate_py<'py>(


### PR DESCRIPTION
Addressing issue #16 I added the variable `__version__` to the `PyModule`, which is set to the same version as set in `Cargo.toml`.