### PR TITLE
Reference our copy of the KaTeX header instead of reyling on docs.rs build cache

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -205,7 +205,7 @@ dependencies = [
 
 [[package]]
 name = "gstools-core"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "approx",
  "criterion",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -44,7 +44,4 @@ name = "main"
 harness = false
 
 [package.metadata.docs.rs]
-rustdoc-args = [
-    "--html-in-header",
-    ".cargo/registry/src/github.com-1ecc6299db9ec823/katex-doc-0.1.0/katex.html",
-]
+rustdoc-args = ["--html-in-header", "katex-header.html"]

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ A Rust implementation of the core algorithms of [GSTools][gstools_link].
 
 This crate includes
 
-- randomization methods for teh random field generation
+- randomization methods for the random field generation
 - the matrix operations of the kriging methods
 - the variogram estimation
 


### PR DESCRIPTION
As can be seen in https://docs.rs/crate/gstools-core/0.2.1/builds/501832 relying on the docs.rs build cache is not always reliable. Following the suggestion from the katex-doc README, I tried to fix this by relying on our own copy of the KaTeX header but I could obviously not test this on docs.rs yet.